### PR TITLE
Wayland Compat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ keywords = ["glfw", "opengl", "egui", "gui", "gamedev"]
 include = ["**/*.rs", "Cargo.toml"]
 
 [dependencies]
-gl = "0.14"
-glfw = "0.55"
-egui = "0.26"
+gl = { version = "0.14" }
+glfw = { version = "0.55", default-features = false }
+egui = { version = "0.27" }
 
 [dependencies.clipboard]
 package = "cli-clipboard"
@@ -27,3 +27,5 @@ optional = true
 
 [features]
 default = ["clipboard"]
+wayland = ["glfw/glfw-sys", "glfw/wayland"]
+rwh-06 = ["glfw/raw-window-handle-v0-6"]


### PR DESCRIPTION
- Expose wayland features from internal crates and bump egui version to 0.27
I noticed while using this lib that being able to enable these features would make my project cross compatible in a better way, make me able to run this on my setup. 