### PR TITLE
remove unnecessary mutable reference

### DIFF
--- a/src/painter.rs
+++ b/src/painter.rs
@@ -300,7 +300,7 @@ impl Painter {
         (self.canvas_width, self.canvas_height) = (w, h);
     }
 
-    pub fn new(window: &mut glfw::Window) -> Painter {
+    pub fn new(window: &glfw::Window) -> Painter {
         let vs = compile_shader(VS_SRC, gl::VERTEX_SHADER);
         let fs = compile_shader(FS_SRC, gl::FRAGMENT_SHADER);
 


### PR DESCRIPTION
### Fix Borrow Errors by Removing Unnecessary Mutability in `Painter` Constructor  

#### Summary  
The `Painter` constructor previously contained a **mutable reference** to `glfw::PWindow`, despite not needing mutability. This caused **borrow checker errors** when attempting to use the window elsewhere.  

#### Changes Made  
- **Removed `mut` from the `glfw::PWindow` reference** in the `Painter` constructor.  