### PR TITLE
Fixed egui warning in example (mentioned in #6)

### DIFF
--- a/examples/demo/main.rs
+++ b/examples/demo/main.rs
@@ -46,6 +46,7 @@ fn main() {
 
     let (width, height) = window.get_framebuffer_size();
     let native_pixels_per_point = window.get_content_scale().0;
+    egui_ctx.set_pixels_per_point(native_pixels_per_point);
 
     let mut egui_input_state = egui_backend::EguiInputState::new(
         egui::RawInput {


### PR DESCRIPTION
In #6, it was mentioned by @oddman621 that there was a warning in the example:

```
epaint: WARNING: pixels_per_point (dpi scale) have changed between text layout and tessellation. You must recreate your text shapes if pixels_per_point changes.
```

so this is a small pull request to fix the demo (once again, I don't believe this requires any version bump.

I haven't seen a pull request for this yet so I figured I can just fix it quickly. I implemented the fix @oddman621 said worked for them though I haven't tested it just yet so some testing might be appropriate before this is merged (just change the content display scale to be 1.5 and then see if the warning remains).